### PR TITLE
[rpm] Improve RPM spec file and systemd unit definition

### DIFF
--- a/memoptimizer.service
+++ b/memoptimizer.service
@@ -5,6 +5,7 @@ After=systemd-sysctl.service local-fs.target default.target
 
 [Service]
 Type=forking
+EnvironmentFile=-/etc/sysconfig/memoptimizer
 ExecStart=/usr/sbin/memoptimizer
 KillMode=control-group
 Restart=on-failure

--- a/memoptimizer.spec
+++ b/memoptimizer.spec
@@ -2,79 +2,66 @@ Name: memoptimizer
 Version: 1.0
 Release: 4%{?dist}
 License: GPLv2
-Group: Applications/System
 Summary: Free memory optimizer
-Source0: %{name}-%{version}.tar.xz
+URL: https://github.com/oracle/memoptimizer
+Source0: %{name}-%{version}.tar.gz
+
+BuildRequires: glib2-devel
+BuildRequires: pkgconfig
+BuildRequires: gcc
+BuildRequires: make
 
 Requires(post): systemd-units
 Requires(preun): systemd-units
 Requires(postun): systemd-units
-Requires(pre): coreutils
-BuildRequires: glib2-devel
-BuildRequires: pkgconfig
-BuildRequires: systemd-units
-
-
-#START INSERT
 
 %description
-memoptimizer monitors the state of free pages by reading kernel
-provided files under /proc/and /sys. Based upon current rate of
-free pages consumption and memory fragmentation, it predicts if
-system is likely to run out of memory or if memory will become
-severely fragmented in near future. If so, it adjusts watermarks
-to force memory reclamation if system is about to run out of
-memory. If memory is precited to become severely fragmented, it
-triggers comapction in the kernel. The goal is to avert memory
-shortage and/or fragmentation by taking proactive measures.
+%{name} monitors the state of free pages by reading kernel provided
+files under /proc and /sys. Based upon the current rate of free page
+consumption and memory fragmentation, it predicts if the system is
+likely to run out of memory, or if memory will become severely
+fragmented in the near future. If so, it adjusts watermarks to force
+memory reclamation. If memory is predicted to become severely
+fragmented, it triggers compaction in the kernel. The goal is to avert
+memory shortage and/or fragmentation by taking proactive measures.
 
 %prep
-%setup -q 
-
+%setup -q
 
 %build
-export CFLAGS="-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2"
-make
+make %{?_smp_mflags}
 
 %install
 
-install -m 755 -D memoptimizer $RPM_BUILD_ROOT/%{_sbindir}/memoptimizer
-install -d -m755 $RPM_BUILD_ROOT/%{_unitdir}
-install -d -m755 $RPM_BUILD_ROOT/%{_presetdir}
-install -m644 memoptimizer.service $RPM_BUILD_ROOT/%{_unitdir}/memoptimizer.service
-install -m644 50-memoptimizer.preset $RPM_BUILD_ROOT/%{_presetdir}/50-memoptimizer.preset
-install -d $RPM_BUILD_ROOT/etc/sysconfig/
-install -m644 memoptimizer.cfg $RPM_BUILD_ROOT/etc/sysconfig/memoptimizer
-install -d -m755 $RPM_BUILD_ROOT/%{_mandir}/man8
-install memoptimizer.8 $RPM_BUILD_ROOT%{_mandir}/man8/
-
+install -D -m 755 memoptimizer %{buildroot}%{_sbindir}/memoptimizer
+install -D -m 644 memoptimizer.service %{buildroot}%{_unitdir}/memoptimizer.service
+install -D -m 644 50-memoptimizer.preset %{buildroot}%{_presetdir}/50-memoptimizer.preset
+install -D -m 644 memoptimizer.cfg %{buildroot}%{_sysconfdir}/sysconfig/memoptimizer
+install -D -m 644 memoptimizer.8 %{buildroot}%{_mandir}/man8/memoptimizer.8
 
 %post
-# Initial installation
 %systemd_post memoptimizer.service
 
 %postun
 %systemd_postun_with_restart memoptimizer.service
 
 %preun
-# Package removal, not upgrade
 %systemd_preun memoptimizer.service
 
-
 %files
-%attr(0755,root,root) %{_sbindir}/memoptimizer
 %license LICENSE.txt
 %doc README.md CONTRIBUTING.md SECURITY.md
-%attr(0644,root,root) %{_mandir}/man8/memoptimizer.8*
 %attr(0640,root,root) %config(noreplace) /etc/sysconfig/memoptimizer
-%attr(0644,root,root) %{_unitdir}/memoptimizer.service
-%attr(0644,root,root) %{_presetdir}/50-memoptimizer.preset
+%{_sbindir}/memoptimizer
+%{_mandir}/man8/memoptimizer.8*
+%{_unitdir}/memoptimizer.service
+%{_presetdir}/50-memoptimizer.preset
 
 %changelog
 * Wed Dec 23 2020 Khalid Aziz <khalid.aziz@oracle.com> - 1.0-4
 - Fixed a formatting error in man page
 
-* Mon Nov 01 2020 Khalid Aziz <khalid.aziz@oracle.com> - 1.0-3
+* Mon Nov 2 2020 Khalid Aziz <khalid.aziz@oracle.com> - 1.0-3
 - Added more documentation and updated spec file to enable memoptimizer
   daemon using a preset file but not start the daemon
 
@@ -86,4 +73,3 @@ install memoptimizer.8 $RPM_BUILD_ROOT%{_mandir}/man8/
 
 * Tue Aug 04 2020 Khalid Aziz <khalid.aziz@oracle.com> - 0.8
 - Initial release
-


### PR DESCRIPTION
Align with Fedora Packaging Guidelines (where appropriate) while
still maintaining compatibility with EL7-based distributions.

Note that Releases on GitHub should only contain the `%{version}` and not include the `%{release}`, i.e. tags should be `1.0` without the `-4`. That's an RPM-specific value. If you want to use semantic versioning, you should tag `1.0.4` and the RPM release should be `-1`.

Signed-off-by: Avi Miller <avi.miller@oracle.com>