### PR TITLE
adaptived: ftests: Delete temporary conf files

### DIFF
--- a/adaptived/tests/ftests/1000-sudo-effect-sd_bus_setting_set_int.c
+++ b/adaptived/tests/ftests/1000-sudo-effect-sd_bus_setting_set_int.c
@@ -40,6 +40,8 @@
 
 static const char * const cgroup_slice_name = "sudo1000.slice";
 static const int expected_value = 89997312; /* Must be multiple of 4K */
+static const char * const old_conf_file = "/etc/systemd/system.control/sudo1000.slice.d/50-MemoryMax.conf";
+static const char * const old_unit_file_dir = "/etc/systemd/system.control/sudo1000.slice.d";
 
 int main(int argc, char *argv[])
 {
@@ -47,6 +49,13 @@ int main(int argc, char *argv[])
 	char config_path[FILENAME_MAX];
 	struct adaptived_ctx *ctx = NULL;
 	int ret, version;
+
+	/*
+	 * systemd will read from old conf files rather than the cgroup sysfs.  Therefore
+	 * delete them
+	 */
+	delete_file(old_conf_file);
+	delete_dir(old_unit_file_dir);
 
 	snprintf(config_path, FILENAME_MAX - 1, "%s/1000-sudo-effect-sd_bus_setting_set_int.json", argv[1]);
 	config_path[FILENAME_MAX - 1] = '\0';

--- a/adaptived/tests/ftests/1001-sudo-effect-sd_bus_setting_add_int.c
+++ b/adaptived/tests/ftests/1001-sudo-effect-sd_bus_setting_add_int.c
@@ -40,6 +40,8 @@
 
 static const char * const cgroup_slice_name = "sudo1001.slice";
 static const int expected_value = 90001408; /* Must be multiple of 4K */
+static const char * const old_conf_file = "/etc/systemd/system.control/sudo1001.slice.d/50-MemoryMax.conf";
+static const char * const old_unit_file_dir = "/etc/systemd/system.control/sudo1001.slice.d";
 
 int main(int argc, char *argv[])
 {
@@ -47,6 +49,13 @@ int main(int argc, char *argv[])
 	char config_path[FILENAME_MAX];
 	struct adaptived_ctx *ctx = NULL;
 	int ret, version;
+
+	/*
+	 * systemd will read from old conf files rather than the cgroup sysfs.  Therefore
+	 * delete them
+	 */
+	delete_file(old_conf_file);
+	delete_dir(old_unit_file_dir);
 
 	snprintf(config_path, FILENAME_MAX - 1, "%s/1001-sudo-effect-sd_bus_setting_add_int.json", argv[1]);
 	config_path[FILENAME_MAX - 1] = '\0';

--- a/adaptived/tests/ftests/1002-sudo-effect-sd_bus_setting_sub_int.c
+++ b/adaptived/tests/ftests/1002-sudo-effect-sd_bus_setting_sub_int.c
@@ -40,6 +40,8 @@
 
 static const char * const cgroup_slice_name = "sudo1002.slice";
 static const int expected_value = 89993216; /* Must be multiple of 4K */
+static const char * const old_conf_file = "/etc/systemd/system.control/sudo1002.slice.d/50-MemoryMax.conf";
+static const char * const old_unit_file_dir = "/etc/systemd/system.control/sudo1002.slice.d";
 
 int main(int argc, char *argv[])
 {
@@ -47,6 +49,13 @@ int main(int argc, char *argv[])
 	char config_path[FILENAME_MAX];
 	struct adaptived_ctx *ctx = NULL;
 	int ret, version;
+
+	/*
+	 * systemd will read from old conf files rather than the cgroup sysfs.  Therefore
+	 * delete them
+	 */
+	delete_file(old_conf_file);
+	delete_dir(old_unit_file_dir);
 
 	snprintf(config_path, FILENAME_MAX - 1, "%s/1002-sudo-effect-sd_bus_setting_sub_int.json", argv[1]);
 	config_path[FILENAME_MAX - 1] = '\0';

--- a/adaptived/tests/ftests/1003-sudo-effect-sd_bus_setting-CPUQuota.c
+++ b/adaptived/tests/ftests/1003-sudo-effect-sd_bus_setting-CPUQuota.c
@@ -41,6 +41,9 @@
 static const char * const cgroup_slice_name = "sudo1003.slice";
 static const int expected_quota = 440000;
 static const int expected_period = 1000000;
+static const char * const old_conf_file1 = "/etc/systemd/system.control/sudo1003.slice.d/50-CPUQuota.conf";
+static const char * const old_conf_file2 = "/etc/systemd/system.control/sudo1003.slice.d/50-CPUQuotaPeriodSec.conf";
+static const char * const old_unit_file_dir = "/etc/systemd/system.control/sudo1003.slice.d";
 
 int main(int argc, char *argv[])
 {
@@ -54,6 +57,14 @@ int main(int argc, char *argv[])
 	char * line = NULL;
 	size_t len = 0;
 	ssize_t read;
+
+	/*
+	 * systemd will read from old conf files rather than the cgroup sysfs.  Therefore
+	 * delete them
+	 */
+	delete_file(old_conf_file1);
+	delete_file(old_conf_file2);
+	delete_dir(old_unit_file_dir);
 
 	snprintf(config_path, FILENAME_MAX - 1, "%s/1003-sudo-effect-sd_bus_setting-CPUQuota.json", argv[1]);
 	config_path[FILENAME_MAX - 1] = '\0';

--- a/adaptived/tests/ftests/1004-sudo-effect-sd_bus_setting_add_int_infinity.c
+++ b/adaptived/tests/ftests/1004-sudo-effect-sd_bus_setting_add_int_infinity.c
@@ -41,6 +41,8 @@
 static const char * const cgroup_slice_name = "sudo1004.slice";
 static const long long expected_value_v1 = 9223372036854771712;
 static const char * expected_value_v2 = "max\n";
+static const char * const old_conf_file = "/etc/systemd/system.control/sudo1004.slice.d/50-MemoryMax.conf";
+static const char * const old_unit_file_dir = "/etc/systemd/system.control/sudo1004.slice.d";
 
 int main(int argc, char *argv[])
 {
@@ -48,6 +50,13 @@ int main(int argc, char *argv[])
 	char config_path[FILENAME_MAX];
 	struct adaptived_ctx *ctx = NULL;
 	int ret, version;
+
+	/*
+	 * systemd will read from old conf files rather than the cgroup sysfs.  Therefore
+	 * delete them
+	 */
+	delete_file(old_conf_file);
+	delete_dir(old_unit_file_dir);
 
 	snprintf(config_path, FILENAME_MAX - 1, "%s/1004-sudo-effect-sd_bus_setting_add_int_infinity.json", argv[1]);
 	config_path[FILENAME_MAX - 1] = '\0';

--- a/adaptived/tests/ftests/1005-sudo-effect-sd_bus_setting_sub_infinity.c
+++ b/adaptived/tests/ftests/1005-sudo-effect-sd_bus_setting_sub_infinity.c
@@ -40,6 +40,8 @@
 
 static const char * const cgroup_slice_name = "sudo1005.slice";
 static long long expected_value;
+static const char * const old_conf_file = "/etc/systemd/system.control/sudo1005.slice.d/50-MemoryMax.conf";
+static const char * const old_unit_file_dir = "/etc/systemd/system.control/sudo1005.slice.d";
 
 int main(int argc, char *argv[])
 {
@@ -53,6 +55,13 @@ int main(int argc, char *argv[])
         FILE *fp;
         char *line = NULL;
         size_t len = 0;
+
+	/*
+	 * systemd will read from old conf files rather than the cgroup sysfs.  Therefore
+	 * delete them
+	 */
+	delete_file(old_conf_file);
+	delete_dir(old_unit_file_dir);
 
 	snprintf(config_path, FILENAME_MAX - 1, "%s/1005-sudo-effect-sd_bus_setting_sub_infinity.json", argv[1]);
 	config_path[FILENAME_MAX - 1] = '\0';

--- a/adaptived/tests/ftests/1006-sudo-effect-sd_bus_setting_set_int_scope.c
+++ b/adaptived/tests/ftests/1006-sudo-effect-sd_bus_setting_set_int_scope.c
@@ -41,6 +41,8 @@
 static const char * const cgroup_scope_name = "sudo1006.scope";
 static const char * const cgroup_slice_scope_name = "system.slice/sudo1006.scope";
 static const int expected_value = 89997312; /* Must be multiple of 4K */
+static const char * const old_conf_file = "/etc/systemd/system.control/sudo1006.slice.d/50-MemoryMax.conf";
+static const char * const old_unit_file_dir = "/etc/systemd/system.control/sudo1006.slice.d";
 
 int main(int argc, char *argv[])
 {
@@ -48,6 +50,13 @@ int main(int argc, char *argv[])
 	char config_path[FILENAME_MAX];
 	struct adaptived_ctx *ctx = NULL;
 	int ret, version;
+
+	/*
+	 * systemd will read from old conf files rather than the cgroup sysfs.  Therefore
+	 * delete them
+	 */
+	delete_file(old_conf_file);
+	delete_dir(old_unit_file_dir);
 
 	snprintf(config_path, FILENAME_MAX - 1, "%s/1006-sudo-effect-sd_bus_setting_set_int_scope.json", argv[1]);
 	config_path[FILENAME_MAX - 1] = '\0';

--- a/adaptived/tests/ftests/1007-sudo-effect-sd_bus_setting_set_str.c
+++ b/adaptived/tests/ftests/1007-sudo-effect-sd_bus_setting_set_str.c
@@ -42,12 +42,21 @@
 #define EXPECTED_RET -ETIME
 
 static const char * const cgroup_slice_name = "sudo1007.slice";
+static const char * const old_conf_file = "/etc/systemd/system.control/sudo1007.slice.d/50-DevicePolicy.conf";
+static const char * const old_unit_file_dir = "/etc/systemd/system.control/sudo1007.slice.d";
 
 int main(int argc, char *argv[])
 {
 	char config_path[FILENAME_MAX];
 	struct adaptived_ctx *ctx = NULL;
 	int ret;
+
+	/*
+	 * systemd will read from old conf files rather than the cgroup sysfs.  Therefore
+	 * delete them
+	 */
+	delete_file(old_conf_file);
+	delete_dir(old_unit_file_dir);
 
 	snprintf(config_path, FILENAME_MAX - 1, "%s/1007-sudo-effect-sd_bus_setting_set_str.json", argv[1]);
 	config_path[FILENAME_MAX - 1] = '\0';


### PR DESCRIPTION
Systemd will write conf files to /etc/ for the sudo tests and will read from these conf files rather than /sys/fs/cgroup.  Delete these temporary configuration files so that the tests properly interact with the cgroup sysfs.